### PR TITLE
Have PaperTrail::Version inherit from ActiveRecord::Base

### DIFF
--- a/lib/paper_trail/frameworks/active_record/models/paper_trail/version.rb
+++ b/lib/paper_trail/frameworks/active_record/models/paper_trail/version.rb
@@ -10,7 +10,7 @@ module PaperTrail
   #
   # The paper_trail-association_tracking gem provides a related model,
   # `VersionAssociation`.
-  class Version < ApplicationRecord
+  class Version < ::ActiveRecord::Base # rubocop:disable Rails/ApplicationRecord
     include PaperTrail::VersionConcern
   end
 end


### PR DESCRIPTION
... not `ApplicationRecord` .

This reverts an unsafe autocorrection (which, indeed, I opted into unsafe autocorrections) that was made here https://github.com/davidrunger/paper_trail/pull/3/files#diff-dae07495a85a2769195e9a2ad41b47eb986c7a1ece4fd2fa44f1e4f2be5e60b1R13 .